### PR TITLE
fix setting listening port

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "export NODE_OPTIONS=--openssl-legacy-provider; next build",
-    "start": "next start -p process.env.PORT"
+    "start": "next start -p ${PORT}"
   },
   "dependencies": {
     "classnames": "2.2.6",


### PR DESCRIPTION
The `process` is the global object in javascript code for Node.js, so it cannot be accessed directly in `npm start`.